### PR TITLE
Incorrect type hint for $help on command stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ class Test extends Command implements CommandInterface
     /**
      * command help
      *
-     * @var string
+     * @var array
      */
     protected $help  = [
 

--- a/src/Conso/Commands/Command.php
+++ b/src/Conso/Commands/Command.php
@@ -42,7 +42,7 @@ class Command extends BaseCommand implements CommandInterface
     /**
      * command help.
      *
-     * @var string
+     * @var array
      */
     protected $help = [
         'sub commands' => [

--- a/src/Conso/Commands/stubs/command
+++ b/src/Conso/Commands/stubs/command
@@ -37,7 +37,7 @@ class #command# extends Command implements CommandInterface
     /**
      * command help
      *
-     * @var string
+     * @var array
      */
     protected $help  = [
 

--- a/tests/Unit/Mocks/Make.php
+++ b/tests/Unit/Mocks/Make.php
@@ -40,7 +40,7 @@ class Make extends BaseCommand implements CommandInterface
     /**
      * command help.
      *
-     * @var string
+     * @var array
      */
     protected $help = [
     ];


### PR DESCRIPTION
The type hint for `$help` is string, however `$help` takes an array.﻿
