### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/src/Conso/Testing/TestCase.php
+++ b/src/Conso/Testing/TestCase.php
@@ -31,7 +31,7 @@ class TestCase extends PHPUnitTestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->output = new Output();
         $this->output->disableAnsi();

--- a/tests/Unit/CommandInvokerTest.php
+++ b/tests/Unit/CommandInvokerTest.php
@@ -33,7 +33,7 @@ class CommandInvokerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/CommandLinkerTest.php
+++ b/tests/Unit/CommandLinkerTest.php
@@ -33,7 +33,7 @@ class CommandLinkerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/CommandsTableTest.php
+++ b/tests/Unit/CommandsTableTest.php
@@ -31,7 +31,7 @@ class CommandsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->table = new CommandsTable();
     }

--- a/tests/Unit/ConsoTest.php
+++ b/tests/Unit/ConsoTest.php
@@ -25,7 +25,7 @@ class ConsoTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/Unit/InputTest.php
+++ b/tests/Unit/InputTest.php
@@ -31,7 +31,7 @@ class InputTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->input = new Input('make:controller user --crud --test=value');
     }

--- a/tests/Unit/OutputTest.php
+++ b/tests/Unit/OutputTest.php
@@ -24,7 +24,7 @@ class OutputTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` method.